### PR TITLE
Clear indexable and deleteable arrays in SearchableSubscriber...

### DIFF
--- a/src/Subscribers/SearchableSubscriber.php
+++ b/src/Subscribers/SearchableSubscriber.php
@@ -59,9 +59,13 @@ class SearchableSubscriber implements EventSubscriber
             $this->indexEntity($args->getEntityManager(), $event);
         }
 
+        $this->indexable = [];
+
         foreach ($this->deleteable as $event) {
             $this->removeEntity($args->getEntityManager(), $event);
         }
+
+        $this->deleteable = [];
     }
 
     /**


### PR DESCRIPTION
Clear indexable and deleteable arrays in SearchableSubscriber, otherwise can run into scenarios where we index / delete the same entity many, many, many times.

I have a script which looped over 12 'pending' jobs from the DB. This script ended up updating those 12 entities to 'processed', and creating 12 new entities. Due to these 2 arrays never being emptied, we ended up creating ~1200 queued jobs! Every iteration of the loop resulted in 2 more entities being added, and then everything from before + these 2 new ones being indexed.

This PR fixes that.