### PR TITLE
clear the entity manager while doing batch imports

### DIFF
--- a/src/SearchableRepository.php
+++ b/src/SearchableRepository.php
@@ -130,6 +130,8 @@ class SearchableRepository extends EntityRepository
                 return false;
             }
 
+            $this->getEntityManager()->clear();
+
             $first += $count;
 
             $results = $qb


### PR DESCRIPTION
Doing imports with a large amount of models frequently causes the memory issues.
This PR clears the entity manager between loops in the chunk method. 
My case: importing 8000 models used 326446776 of memory - with this PR it goes down to 33360760 peak usage.
