### PR TITLE
Import command 

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -57,6 +57,8 @@ class ImportCommand extends Command
 
         $repository->makeAllSearchable();
 
+        $events->forget(ModelsImported::class);
+
         $this->info('All [' . $class . '] records have been imported.');
     }
 }

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -47,7 +47,12 @@ class ImportCommand extends Command
         }
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
-            $this->line('<comment>Imported [' . $class . '] models up to ID:</comment> ' . $event->models->last()->getKey());
+            $this->line(sprintf(
+                '<comment>Imported %d [%s] models up to ID: %s</comment>',
+                $event->models->count(),
+                $class,
+                $event->models->last()->getKey()
+            ));
         });
 
         $repository->makeAllSearchable();

--- a/src/SearchableRepository.php
+++ b/src/SearchableRepository.php
@@ -130,6 +130,8 @@ class SearchableRepository extends EntityRepository
                 return false;
             }
 
+            $this->getEntityManager()->clear();
+
             $first += $count;
 
             $results = $qb


### PR DESCRIPTION
When the import is used in a loop with multiple models these are reported multiple times in the output.
The fix here is to `forget` an event once it's been processed.

This PR also adds a count to the output to give a clearer indication of what has been imported.